### PR TITLE
Returns HTTP Status ServiceUnavailable if no provider is available

### DIFF
--- a/src/internal/server/proxy_handler.go
+++ b/src/internal/server/proxy_handler.go
@@ -78,10 +78,12 @@ func ServiceForwardHandler(c *gin.Context) {
 	service, err := protocol.GetService(serviceName)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 	body, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
 	target := url.URL{
 		Scheme: "http",
@@ -112,10 +114,12 @@ func GlobalServiceForwardHandler(c *gin.Context) {
 	providers, err := protocol.GetAllProviders(serviceName)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 	body, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
 	// find proper service that are within the same identity group
 	// first filter by service name, then iterative over the identity groups
@@ -148,6 +152,11 @@ func GlobalServiceForwardHandler(c *gin.Context) {
 			}
 		}
 	}
+	if len(candidates) < 1 {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "No provider found for the rquested service."})
+		return
+	}
+	
 	// randomly select one of the candidates
 	// here's where we can implement a load balancing algorithm
 	randomIndex := rand.Intn(len(candidates))

--- a/src/internal/server/proxy_handler.go
+++ b/src/internal/server/proxy_handler.go
@@ -153,7 +153,7 @@ func GlobalServiceForwardHandler(c *gin.Context) {
 		}
 	}
 	if len(candidates) < 1 {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "No provider found for the rquested service."})
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "No provider found for the requested service."})
 		return
 	}
 	


### PR DESCRIPTION
Returns error if no provider is found. 
Should fix this issue found in logs:
```
invalid argument to Intn
math/rand/rand.go:180 (0x64a06b)
math/rand/rand.go:453 (0x64ac44)
ocf/internal/server/proxy_handler.go:153 (0x149d744) github.com/gin-gonic/gin@v1.10.0/context.go:185 (0x138dc2e) github.com/gin-gonic/gin@v1.10.0/recovery.go:102 (0x138dc1b) github.com/gin-gonic/gin@v1.10.0/context.go:185 (0x138dc2e) github.com/gin-gonic/gin@v1.10.0/recovery.go:102 (0x138dc1b) github.com/gin-gonic/gin@v1.10.0/context.go:185 (0x138cd64) github.com/gin-gonic/gin@v1.10.0/logger.go:249 (0x138cd4b) github.com/gin-gonic/gin@v1.10.0/context.go:185 (0x138c151) github.com/gin-gonic/gin@v1.10.0/gin.go:633 (0x138bbc0) github.com/gin-gonic/gin@v1.10.0/gin.go:589 (0x138b6f1) net/http/server.go:3210 (0x7d85ad)
net/http/server.go:2092 (0x7b7acf)
runtime/asm_amd64.s:1700 (0x479840)
```