### PR TITLE
Handles node disconnect

### DIFF
--- a/src/internal/protocol/host.go
+++ b/src/internal/protocol/host.go
@@ -150,7 +150,7 @@ func AllPeers() []*PeerWithStatus {
 
 func ConnectedBootstraps() []string {
 	var bootstraps = []string{}
-	dnt := GetNodeTable(false)
+	dnt := GetNodeTable()
 	host, _ := GetP2PNode(nil)
 	for _, p := range *dnt {
 		if p.PublicAddress != "" {

--- a/src/internal/protocol/node_table.go
+++ b/src/internal/protocol/node_table.go
@@ -131,7 +131,7 @@ func DeleteNodeTableHook(key ds.Key) {
 
 func GetPeerFromTable(peerId string) (Peer, error) {
 	table := *GetNodeTable()
-	peer, ok := table[peerId]
+	peer, ok := table["/"+peerId]
 	if !ok {
 		return Peer{}, errors.New("peer not found")
 	}

--- a/src/internal/protocol/node_table.go
+++ b/src/internal/protocol/node_table.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 
 	ds "github.com/ipfs/go-datastore"
-	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/spf13/viper"
 )
 
@@ -49,6 +47,8 @@ type Peer struct {
 	Version           string              `json:"version"`
 	PublicAddress     string              `json:"public_address"`
 	Hardware          common.HardwareSpec `json:"hardware"`
+	Connected         bool                `json:"connected"`
+	Load              []int               `json:"load"`
 }
 
 type PeerWithStatus struct {
@@ -61,26 +61,10 @@ type NodeTable map[string]Peer
 
 var dnt *NodeTable
 
-func GetNodeTable(reachableOnly bool) *NodeTable {
+func GetNodeTable() *NodeTable {
 	dntOnce.Do(func() {
 		dnt = &NodeTable{}
 	})
-	if reachableOnly {
-		host, _ := GetP2PNode(nil)
-		// filter out the nodes that are not connected
-		for _, p := range *dnt {
-			if host.Network().Connectedness(peer.ID(p.ID)) != network.Connected && p.ID != host.ID().String() {
-				// try to dial the peer
-				conn, err := host.Network().DialPeer(context.Background(), peer.ID(p.ID))
-				if err != nil {
-					common.Logger.Info("Peer: ", p.ID, " removed from table: ", err)
-					// delete(*dnt, key)
-				} else {
-					defer conn.Close()
-				}
-			}
-		}
-	}
 	return dnt
 }
 
@@ -133,7 +117,7 @@ func DeleteNodeTable() {
 }
 
 func UpdateNodeTableHook(key ds.Key, value []byte) {
-	table := *GetNodeTable(false)
+	table := *GetNodeTable()
 	var peer Peer
 	err := json.Unmarshal(value, &peer)
 	common.ReportError(err, "Error while unmarshalling peer")
@@ -141,12 +125,12 @@ func UpdateNodeTableHook(key ds.Key, value []byte) {
 }
 
 func DeleteNodeTableHook(key ds.Key) {
-	table := *GetNodeTable(false)
+	table := *GetNodeTable()
 	delete(table, key.String())
 }
 
 func GetPeerFromTable(peerId string) (Peer, error) {
-	table := *GetNodeTable(false)
+	table := *GetNodeTable()
 	peer, ok := table[peerId]
 	if !ok {
 		return Peer{}, errors.New("peer not found")
@@ -173,11 +157,13 @@ func GetService(name string) (Service, error) {
 
 func GetAllProviders(serviceName string) ([]Peer, error) {
 	var providers []Peer
-	table := *GetNodeTable(false)
+	table := *GetNodeTable()
 	for _, peer := range table {
-		for _, service := range peer.Service {
-			if service.Name == serviceName {
-				providers = append(providers, peer)
+		if peer.Connected {
+			for _, service := range peer.Service {
+				if service.Name == serviceName {
+					providers = append(providers, peer)
+				}
 			}
 		}
 	}

--- a/src/internal/server/crdt_handler.go
+++ b/src/internal/server/crdt_handler.go
@@ -28,6 +28,7 @@ func listBootstraps(c *gin.Context) {
 func updateLocal(c *gin.Context) {
 	var peer protocol.Peer
 	c.BindJSON(&peer)
+	peer.Connected = true
 	protocol.UpdateNodeTable(peer)
 }
 
@@ -42,5 +43,5 @@ func getDNT(c *gin.Context) {
 		{ingest.TimestampField: time.Now(), "event": "DNT Lookup"},
 	}
 	IngestEvents(events)
-	c.JSON(200, protocol.GetNodeTable(false))
+	c.JSON(200, protocol.GetNodeTable())
 }


### PR DESCRIPTION
This PR gracefully handles nodes disconnect by marking them as disconnected if the verification procedure fails to validate the node connection.

Additionally, this PR fixes a critical bug in the GetPeerFromTable method.
 