### PR TITLE
fix race condition bug

### DIFF
--- a/src/internal/protocol/clock.go
+++ b/src/internal/protocol/clock.go
@@ -96,7 +96,7 @@ func StartTicker() {
 		// Cleanup: remove peers that have been disconnected for a long time
 		// Define staleness threshold
 		staleAfter := 10 * time.Minute
-		table := *GetNodeTable()
+		table := *GetAllPeers()
 		now := time.Now().Unix()
 		for id, p := range table {
 			if !p.Connected && p.LastSeen > 0 {

--- a/src/internal/protocol/host.go
+++ b/src/internal/protocol/host.go
@@ -239,7 +239,7 @@ func AllPeers() []*PeerWithStatus {
 
 func ConnectedBootstraps() []string {
 	var bootstraps = []string{}
-	dnt := GetNodeTable()
+	dnt := GetAllPeers()
 	host, _ := GetP2PNode(nil)
 	for _, p := range *dnt {
 		if p.PublicAddress != "" {

--- a/src/internal/protocol/node_table.go
+++ b/src/internal/protocol/node_table.go
@@ -63,7 +63,7 @@ type NodeTable map[string]Peer
 var dnt *NodeTable
 var tableUpdateSem = make(chan struct{}, 1) // capacity 1 → max 1 goroutine at a time
 
-func GetNodeTable() *NodeTable {
+func getNodeTable() *NodeTable {
 	dntOnce.Do(func() {
 		dnt = &NodeTable{}
 	})
@@ -125,7 +125,7 @@ func DeleteNodeTable() {
 }
 
 func UpdateNodeTableHook(key ds.Key, value []byte) {
-	table := *GetNodeTable()
+	table := *getNodeTable()
 	var peer Peer
 	err := json.Unmarshal(value, &peer)
 	common.ReportError(err, "Error while unmarshalling peer")
@@ -145,14 +145,14 @@ func UpdateNodeTableHook(key ds.Key, value []byte) {
 }
 
 func DeleteNodeTableHook(key ds.Key) {
-	table := *GetNodeTable()
+	table := *getNodeTable()
 	tableUpdateSem <- struct{}{}
 	defer func() { <-tableUpdateSem }() // Release on exit
 	delete(table, key.String())
 }
 
 func GetPeerFromTable(peerId string) (Peer, error) {
-	table := *GetNodeTable()
+	table := *getNodeTable()
 	tableUpdateSem <- struct{}{}
 	defer func() { <-tableUpdateSem }() // Release on exit
 	peer, ok := table["/"+peerId]
@@ -166,12 +166,22 @@ func GetConnectedPeers() *NodeTable {
 	var connected = NodeTable{}
 	tableUpdateSem <- struct{}{}
 	defer func() { <-tableUpdateSem }() // Release on exit
-	for id, p := range *GetNodeTable() {
+	for id, p := range *getNodeTable() {
 		if p.Connected {
 			connected[id] = p
 		}
 	}
 	return &connected
+}
+
+func GetAllPeers() *NodeTable {
+	var peers = NodeTable{}
+	tableUpdateSem <- struct{}{}
+	defer func() { <-tableUpdateSem }() // Release on exit
+	for id, p := range *getNodeTable() {
+		peers[id] = p
+	}
+	return &peers
 }
 
 func GetService(name string) (Service, error) {
@@ -193,7 +203,7 @@ func GetService(name string) (Service, error) {
 
 func GetAllProviders(serviceName string) ([]Peer, error) {
 	var providers []Peer
-	table := *GetNodeTable()
+	table := *getNodeTable()
 	tableUpdateSem <- struct{}{}
 	defer func() { <-tableUpdateSem }() // Release on exit
 	for _, peer := range table {

--- a/src/internal/protocol/node_table_test.go
+++ b/src/internal/protocol/node_table_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUpdateNodeTableHookAndGetPeer(t *testing.T) {
-	_ = GetNodeTable()
+	_ = GetAllPeers()
 	p := Peer{ID: "peer1", PublicAddress: "1.2.3.4"}
 	b, _ := json.Marshal(p)
 	UpdateNodeTableHook(ds.NewKey("peer1"), b)
@@ -23,7 +23,7 @@ func TestUpdateNodeTableHookAndGetPeer(t *testing.T) {
 }
 
 func TestDeleteNodeTableHook(t *testing.T) {
-	table := GetNodeTable()
+	table := GetAllPeers()
 	p := Peer{ID: "peer2", PublicAddress: "5.6.7.8"}
 	b, _ := json.Marshal(p)
 	UpdateNodeTableHook(ds.NewKey("peer2"), b)


### PR DESCRIPTION
This PR fixes a race condition when accessing the peer table.
getNodeTable() is now private and only accessible from node_table.go. 