### PR TITLE
Refactor usage record handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@ _internal/
 .env
 __pycache__
 *.out
-
+.omx
 # Website (Fumadocs)
 website/node_modules/
 website/.next/
 website/.source/
+.omx/

--- a/src/internal/protocol/host.go
+++ b/src/internal/protocol/host.go
@@ -74,11 +74,18 @@ func newHost(ctx context.Context, seed int64, ds datastore.Batching) (host.Host,
 	}
 	var priv crypto.PrivKey
 	if seed == 0 {
-		// seed=0: always generate a fresh random identity (no persistence)
-		common.Logger.Debug("seed=0: generating ephemeral random key")
-		priv, _, err = crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
-		if err != nil {
-			return nil, err
+		// seed=0 (default): load existing key from disk for stable identity.
+		// If no key file exists yet, generate a random one and persist it.
+		priv = loadKeyFromFile()
+		if priv == nil {
+			common.Logger.Debug("seed=0: no existing key file, generating and persisting new identity")
+			priv, _, err = crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
+			if err != nil {
+				return nil, err
+			}
+			writeKeyToFile(priv)
+		} else {
+			common.Logger.Debug("seed=0: loaded existing identity from disk")
 		}
 	} else {
 		// seed!=0: use persisted key file for stable identity across restarts.

--- a/src/internal/server/access_control.go
+++ b/src/internal/server/access_control.go
@@ -44,19 +44,18 @@ import (
 //
 // Returns the wallet public key, or "" if the caller cannot be identified.
 func resolveCallerWallet(r *http.Request) string {
-	// Prefer the end-user wallet injected by the head node.
+	if !isLibp2pRemoteAddr(r.RemoteAddr) {
+		return ""
+	}
+
+	// Only trust X-Otela-Client-Wallet when the request arrived over libp2p,
+	// meaning the direct caller is a verified peer (the head node). A plain
+	// HTTP caller could forge this header to bypass access control.
 	if clientWallet := r.Header.Get("X-Otela-Client-Wallet"); clientWallet != "" {
 		return clientWallet
 	}
 
 	addr := r.RemoteAddr
-	// libp2p-http sets RemoteAddr to the raw peer ID string.
-	// Peer IDs start with "12D3" (modern), "Qm" (legacy), or "16Ui".
-	if !strings.HasPrefix(addr, "12D3") &&
-		!strings.HasPrefix(addr, "Qm") &&
-		!strings.HasPrefix(addr, "16Ui") {
-		return ""
-	}
 	peer, err := protocol.GetPeerFromTable(addr)
 	if err != nil {
 		return ""
@@ -137,6 +136,18 @@ func accessControlMiddleware() gin.HandlerFunc {
 
 		c.Next()
 	}
+}
+
+// isLibp2pRemoteAddr returns true when addr looks like a libp2p peer ID.
+// libp2p-http sets http.Request.RemoteAddr to the raw peer ID string
+// (no host:port). Known base58-encoded prefixes:
+//   - "12D3" — Ed25519/identity multihash (current default)
+//   - "Qm"   — SHA2-256 multihash (legacy RSA keys)
+//   - "16Ui" — secp256k1 keys
+func isLibp2pRemoteAddr(addr string) bool {
+	return strings.HasPrefix(addr, "12D3") ||
+		strings.HasPrefix(addr, "Qm") ||
+		strings.HasPrefix(addr, "16Ui")
 }
 
 func containsWallet(list []string, wallet string) bool {

--- a/src/internal/usage/store.go
+++ b/src/internal/usage/store.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -32,7 +33,7 @@ func (s *UsageStore) Close() error {
 
 // SaveRecord persists a usage record
 func (s *UsageStore) SaveRecord(record *UsageRecord) error {
-	key := []byte(fmt.Sprintf("record/%s", record.RequestID))
+	key := []byte(fmt.Sprintf("record/%s/%s", record.RequestID, record.MetricName))
 
 	data, err := json.Marshal(record)
 	if err != nil {
@@ -44,11 +45,11 @@ func (s *UsageStore) SaveRecord(record *UsageRecord) error {
 	})
 }
 
-// GetRecord retrieves a usage record by request ID
-func (s *UsageStore) GetRecord(requestID string) (*UsageRecord, error) {
+// GetRecord retrieves a usage record by request ID and metric name.
+func (s *UsageStore) GetRecord(requestID string, metricName string) (*UsageRecord, error) {
 	var record UsageRecord
 
-	key := []byte(fmt.Sprintf("record/%s", requestID))
+	key := []byte(fmt.Sprintf("record/%s/%s", requestID, metricName))
 
 	err := s.db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(key)
@@ -107,12 +108,14 @@ func (s *UsageStore) GetPendingRecords(consumer, provider, service, metric strin
 	return records, err
 }
 
-// MarkAggregated removes records that have been aggregated
-func (s *UsageStore) MarkAggregated(requestIDs []string) error {
+// MarkAggregated removes records that have been aggregated.
+// Each element in records must be a "requestID/metricName" compound key
+// matching the format used by SaveRecord.
+func (s *UsageStore) MarkAggregated(records []*UsageRecord) error {
 	return s.db.Update(func(txn *badger.Txn) error {
-		for _, id := range requestIDs {
-			key := []byte(fmt.Sprintf("record/%s", id))
-			if err := txn.Delete(key); err != nil {
+		for _, r := range records {
+			key := []byte(fmt.Sprintf("record/%s/%s", r.RequestID, r.MetricName))
+			if err := txn.Delete(key); err != nil && !errors.Is(err, badger.ErrKeyNotFound) {
 				return err
 			}
 		}

--- a/src/internal/usage/store_test.go
+++ b/src/internal/usage/store_test.go
@@ -35,7 +35,7 @@ func TestUsageStore_SaveAndGet(t *testing.T) {
 	}
 
 	// Get
-	retrieved, err := store.GetRecord("test-req-1")
+	retrieved, err := store.GetRecord("test-req-1", "tokens")
 	if err != nil {
 		t.Fatalf("GetRecord failed: %v", err)
 	}
@@ -111,7 +111,10 @@ func TestUsageStore_MarkAggregated(t *testing.T) {
 	}
 
 	// Mark 2 of the 3 as aggregated
-	if err := store.MarkAggregated([]string{"req-0", "req-1"}); err != nil {
+	if err := store.MarkAggregated([]*UsageRecord{
+		{RequestID: "req-0", MetricName: "tokens"},
+		{RequestID: "req-1", MetricName: "tokens"},
+	}); err != nil {
 		t.Fatalf("MarkAggregated failed: %v", err)
 	}
 
@@ -144,7 +147,7 @@ func TestUsageStore_MarkAggregated_EmptyList(t *testing.T) {
 	defer store.Close()
 
 	// Marking an empty list should not error
-	if err := store.MarkAggregated([]string{}); err != nil {
+	if err := store.MarkAggregated([]*UsageRecord{}); err != nil {
 		t.Fatalf("MarkAggregated with empty list should not error, got: %v", err)
 	}
 }
@@ -185,7 +188,7 @@ func TestUsageStore_GetRecord_NotFound(t *testing.T) {
 	defer store.Close()
 
 	// Request a non-existent record
-	_, err = store.GetRecord("does-not-exist")
+	_, err = store.GetRecord("does-not-exist", "tokens")
 	if err == nil {
 		t.Fatal("Expected error when getting non-existent record, got nil")
 	}

--- a/src/tests/integration/billing_pipeline_test.go
+++ b/src/tests/integration/billing_pipeline_test.go
@@ -79,7 +79,7 @@ func TestBillingPipeline_EndToEnd(t *testing.T) {
 
 	require.NoError(t, store.SaveRecord(headRecord))
 
-	got, err := store.GetRecord(requestID)
+	got, err := store.GetRecord(requestID, "tokens")
 	require.NoError(t, err)
 	assert.Equal(t, headRecord.MetricValue, got.MetricValue)
 
@@ -304,7 +304,7 @@ func TestBillingPipeline_StoreRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { store2.Close() })
 
-	got, err := store2.GetRecord("persist-req-1")
+	got, err := store2.GetRecord("persist-req-1", "tokens")
 	require.NoError(t, err)
 	assert.Equal(t, int64(42000), got.MetricValue)
 	assert.Equal(t, "llm", got.Service)
@@ -424,7 +424,10 @@ func TestBillingPipeline_PendingRecordFiltering(t *testing.T) {
 	assert.Equal(t, int64(5000), gpuPending[0].MetricValue)
 
 	// Mark r1, r2 as aggregated — they should disappear
-	require.NoError(t, store.MarkAggregated([]string{"r1", "r2"}))
+	require.NoError(t, store.MarkAggregated([]*usage.UsageRecord{
+		{RequestID: "r1", MetricName: "tokens"},
+		{RequestID: "r2", MetricName: "tokens"},
+	}))
 
 	remaining, err := store.GetPendingRecords("head-1", "w1", "llm", "tokens")
 	require.NoError(t, err)


### PR DESCRIPTION
update `SaveRecord` and `GetRecord` to include metric name, enhance access control checks, and improve key management for identity persistence.